### PR TITLE
throw error when checkstyle fails

### DIFF
--- a/.github/workflows/java-ci-04-build.yml
+++ b/.github/workflows/java-ci-04-build.yml
@@ -11,3 +11,9 @@ jobs:
       - uses: actions/checkout@v3
       - name: Run java checkstyle
         uses: nikitasavinov/checkstyle-action@0.6.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          reporter: 'github-check'
+          tool_name: 'testtool'
+          level: 'error'
+          fail_on_error: true


### PR DESCRIPTION
When the checkstyle is not correct, it should throw an error and not be able to be merged